### PR TITLE
Autocorrect Schemaless URL Input in Website Shocker for Ease of Use

### DIFF
--- a/shellshock.js
+++ b/shellshock.js
@@ -25,6 +25,7 @@ $(function() {
         if (!shocking) {
             shocking = true;
             $("#btn_shock").html('Shocking... <i class="fa fa-spinner fa-spin"></i>');
+            help_complete_url(); // Auto-correct shema-less URL's for ease of use
             var shock_url = $("#test_url").val();
             if (shock_url.length <= 7) {
                 $("#test_errors").html('<div class="alert alert-danger" role="alert"><strong>Invalid URL</strong> Please enter a valid url to test and try again.</div>');
@@ -57,4 +58,19 @@ $(function() {
             console.log('Already shocking!');
         }
     })
+
 })
+
+// If user doesn't specify a schema, suppose it's 'http'
+// and autocorrect the entry
+function help_complete_url() {
+    var shock_url = $("#test_url").val();
+    var url_components = shock_url.split(":");
+    if(url_components[0].length == shock_url.length) {
+        //For now suppose if no schema specified, they wanted 'http'
+        new_shock_url = 'http://'+shock_url;
+        $("#test_url").val(new_shock_url);
+    }
+}
+
+


### PR DESCRIPTION
Thanks for building the Website Shocker Tool! I enjoyed using it but quickly became frustrated when the URL's I was inserting without a schema (i.e http, https) were being rejected as invalid. We are spoiled by chrome and other browsers by being able to search for 'www.google.com' and have it autocorrected to 'http://www.google.com' so I built a quick autocorrect function so others don't feel the same annoyance! 

Hope this helps and keep up the awesome work!
