### PR TITLE
Only upgrade bash and not the whole system

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@ echo "CVE-2014-7187 vulnerable, word_lineno"</pre>
         <p>For Ubuntu Systems:</p>
         <pre>apt-get update; apt-get install --only-upgrade bash</pre> 
         <p>For Arch Linux:</p>
-        <pre>pacman -Syu bash</pre>
+        <pre>pacman -Sy bash</pre>
         <p>
             If your package manager doesn't find an update, you will need to build bash from src.
         </p>


### PR DESCRIPTION
Running `apt-get upgrade` or `pacman -S` might cause a bunch of problems in packages which are completely unrelated to this bug. If you're going to give general advice, you should probably make the commands as specific as possible.
