### PR TITLE
Added dependency check

### DIFF
--- a/fixbash
+++ b/fixbash
@@ -13,8 +13,7 @@
 # REV 6: Bumped patch to 27 from 26.
 # REV 7: Not using sudo when logged in as root: https://github.com/wreiske/shellshocker/pull/15
 # REV 8: Updated loops to download and apply up to latest patch: https://github.com/wreiske/shellshocker/pull/17
-########
-# tuxpowered: Added check for gcc to be installed.
+# REV 9: Added check for gcc to be installed.
 ########
 # This script will download bash 4.3 to your home directory, extract, download patches, patch,
 # install patches, and install the fixed bash.


### PR DESCRIPTION
gcc is required to compile the new bash, an it may not be installed on all system.
Added system check before downloading files to check for gcc to be installed.
