### PR TITLE
fix for BSD's expr - $i needs to be initialized

### DIFF
--- a/fixbash
+++ b/fixbash
@@ -41,6 +41,7 @@ cd bash-shellshocker
 echo "Downloading Bash..."
 wget -N https://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz
 echo "Downloading Bash patches..."
+i=0
 while [ true ]; do i=`expr $i + 1`; wget -N https://ftp.gnu.org/gnu/bash/bash-4.3-patches/bash43-$(printf '%03g' $i); if [ $? -ne 0 ]; then break; fi; done
 echo "Extracting bash from tar.gz..."
 tar zxvf bash-4.3.tar.gz 


### PR DESCRIPTION
BSD's expr has a stricter syntax requirements.
Unitialized $i in the patch download loop were resulting in the omission of any patches.
Added initialization of $i right before entering the loop.
