### PR TITLE
Adds variable exitcode

### DIFF
--- a/shellshock_test.sh
+++ b/shellshock_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+EXITCODE=0
 
 # CVE-2014-6271
 CVE20146271=$(env 'x=() { :;}; echo vulnerable' 'BASH_FUNC_x()=() { :;}; echo vulnerable' bash -c "echo test" 2>&1 | grep 'vulnerable' | wc -l)
@@ -6,6 +7,7 @@ CVE20146271=$(env 'x=() { :;}; echo vulnerable' 'BASH_FUNC_x()=() { :;}; echo vu
 echo -n "CVE-2014-6271 (original shellshock): "
 if [ $CVE20146271 -gt 0 ]; then
 	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+1))
 else
 	echo -e "\033[92mnot vulnerable\033[39m"
 fi
@@ -16,6 +18,7 @@ CVE20146278=$(shellshocker='() { echo vulnerable; }' bash -c shellshocker | grep
 echo -n "CVE-2014-6278 (Florian's patch): "
 if [ $CVE20146278 -gt 0 ]; then
 	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+2))
 else
 	echo -e "\033[92mnot vulnerable\033[39m"
 fi
@@ -26,6 +29,7 @@ CVE20147169=$((cd /tmp; rm -f /tmp/echo; env X='() { (a)=>\' bash -c "echo echo 
 echo -n "CVE-2014-7169 (taviso bug): "
 if [ $CVE20147169 -gt 0 ]; then
 	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+4))
 else
 	echo -e "\033[92mnot vulnerable\033[39m"
 fi
@@ -36,6 +40,7 @@ CVE2014=$(env X=' () { }; echo hello' bash -c 'date' | grep 'hello' | wc -l)
 echo -n "CVE-2014-//// (exploit 3 on http://shellshocker.net/): "
 if [ $CVE2014 -gt 0 ]; then
 	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+8))
 else
 	echo -e "\033[92mnot vulnerable\033[39m"
 fi
@@ -46,6 +51,7 @@ CVE20147186=$((bash -c 'true <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<E
 echo -n "CVE-2014-7186 (redir_stack bug): "
 if [ $CVE20147186 -gt 0 ]; then
 	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+16))
 else
 	echo -e "\033[92mnot vulnerable\033[39m"
 fi
@@ -56,6 +62,9 @@ CVE20147187=$(((for x in {1..200}; do echo "for x$x in ; do :"; done; for x in {
 echo -n "CVE-2014-7187 (nested loops off by one): "
 if [ $CVE20147187 -gt 0 ]; then
 	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+32))
 else
 	echo -e "\033[92mnot vulnerable\033[39m"
 fi
+
+exit $EXITCODE


### PR DESCRIPTION
Adds an exit status to the detection script so it can be evaluated after running (and used in e.g. provisioning frameworks like Chef):
- exits 0 when no vulnerabilities are found
- exits with a cumulative exit code when vulnerabilities are found
- exit code can be used to determine which vulnerabilities were found

HTH, great job!
