### PR TITLE
avoid CVE-2014-6277 misdetection

### DIFF
--- a/shellshock_test.sh
+++ b/shellshock_test.sh
@@ -13,7 +13,8 @@ else
 fi
 
 # CVE-2014-6277
-CVE20146277=$((bash -c "f() { x() { _;}; x() { _;} <<a; }" 2>/dev/null || echo vulnerable) | grep 'vulnerable' | wc -l)
+# it is fully mitigated by the environment function prefix passing avoidance
+CVE20146277=$((shellshocker="() { x() { _;}; x() { _;} <<a; }" bash -c date 2>/dev/null || echo vulnerable) | grep 'vulnerable' | wc -l)
 
 echo -n "CVE-2014-6277 (segfault): "
 if [ $CVE20146277 -gt 0 ]; then


### PR DESCRIPTION
CVE-2014-6277 is only effective if code is based into bash via environemnt as function.

That it crashes in bash itself is only a bug, but not a security issue.
